### PR TITLE
Redirect 404'd pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,5 @@
+<h1>404: Page not found</h1>
+<script type="text/javascript">
+if(~document.location.href.indexOf('/wiki/display'))
+  document.location.href = document.location.href.replace("://www.antlr.org","s://theantlrguy.atlassian.net");
+</script>


### PR DESCRIPTION
Google's search index has a whole bunch of the Confluence pages linked to as if they were on the GitHub site. This snippet will redirect the user to the appropriate Confluence page if the selected page contains `/wiki/display` in the URL.

This makes the site a whole lot more usable.
