### PR TITLE
Use HTTPS in Quick Start section

### DIFF
--- a/index.html
+++ b/index.html
@@ -112,7 +112,7 @@ science at the <a href="http://www.cs.usfca.edu/~parrt">University of San Franci
 OS X
 <pre>
 <span class="dollar">$</span> <span class="cmd">cd</span> /usr/local/lib
-<span class="dollar">$</span> <span class="cmd">sudo curl</span> -O http://www.antlr.org/download/antlr-4.7.1-complete.jar
+<span class="dollar">$</span> <span class="cmd">sudo curl</span> -O https://www.antlr.org/download/antlr-4.7.1-complete.jar
 <span class="dollar">$</span> <span class="cmd">export</span> <span class="equals">CLASSPATH=</span><span class="path">".:/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH"</span>
 <span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">antlr4=</span><span class="path">'java -jar /usr/local/lib/antlr-4.7.1-complete.jar'</span>
 <span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">grun=</span><span class="path">'java org.antlr.v4.gui.TestRig'</span>
@@ -123,7 +123,7 @@ OS X
 LINUX
 <pre>
 <span class="dollar">$</span> <span class="cmd">cd</span> /usr/local/lib
-<span class="dollar">$</span> <span class="cmd">wget</span> http://www.antlr.org/download/antlr-4.7.1-complete.jar
+<span class="dollar">$</span> <span class="cmd">wget</span> https://www.antlr.org/download/antlr-4.7.1-complete.jar
 <span class="dollar">$</span> <span class="cmd">export</span> <span class="equals">CLASSPATH=</span><span class="path">".:/usr/local/lib/antlr-4.7.1-complete.jar:$CLASSPATH"</span>
 <span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">antlr4=</span><span class="path">'java -jar /usr/local/lib/antlr-4.7.1-complete.jar'</span>
 <span class="dollar">$</span> <span class="cmd">alias</span> <span class="equals">grun=</span><span class="path">'java org.antlr.v4.gui.TestRig'</span>
@@ -133,7 +133,7 @@ LINUX
 <div class="slide">
 Windows
 <ol>
-<li>Download <a href="http://antlr.org/download/antlr-4.7.1-complete.jar">http://antlr.org/download/antlr-4.7.1-complete.jar</a>.
+<li>Download <a href="https://antlr.org/download/antlr-4.7.1-complete.jar">https://antlr.org/download/antlr-4.7.1-complete.jar</a>.
 
 <li>Add antlr4-complete.jar to CLASSPATH, either:
 <ul>


### PR DESCRIPTION
This branch replaces insecure HTTP with secure HTTPS in the download examples of the Quick Start section.