### PR TITLE
Visual Studio IDE support

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -75,7 +75,8 @@ woopra.track();
 	
 <h1>ANTLR Development Tools</h1>
 
-<img align=left src="images/icons/rocket.png">There are plug-ins for Intellij, NetBeans, Eclipse, Visual Studio Code, and jEdit.<br><br>
+<img align=left src="images/icons/rocket.png">There are plug-ins for
+Intellij, NetBeans, Eclipse, Visual Studio Code, Visual Studio IDE, and jEdit.<br><br>
 
 <h2>Intellij Plugin for ANTLR 4</h2>
 
@@ -195,6 +196,24 @@ Mike Lischke created an <a href="https://marketplace.visualstudio.com/items?item
 <li>Rule reference counts via code lens.
 <li>Railroad diagrams for all types of rules (parser, lexer, fragment lexer).
 <li>ATN graphs for all rule types. This is a visualization of the internal ATN that drives lexers + parsers. It uses D3.js for layout and interaction. Nodes can be repositioned with the mouse and you can drag and zoom the image. The transformation and position state is restored when reopening a graph.
+</ul>
+
+<br>
+<h2>Visual Studio IDE extension for ANTLR 4</h2>
+
+<p>
+Ken Domino created an
+<a href="https://marketplace.visualstudio.com/items?itemName=KenDomino.AntlrVSIX">ANTLR
+   4 extention for Visual Studio 2019</a>. Features:
+
+<ul>
+<li>Syntax highlighting for ANTLR grammars (.g and .g4 files).
+<li>Quick navigation for next and previous rules in grammar.
+<li>Intellisense command completion and tooltips.
+<li>Go to def/refs.
+<li>Go to C# visitor and listener methods, with generation if missing.
+<li>Support for integrated C# parser generation via Antlr Java tool, compile, and debug.
+<li>Templates for NET Code and Framework Antlr examples.
 </ul>
 
 <br>

--- a/tools.html
+++ b/tools.html
@@ -75,8 +75,7 @@ woopra.track();
 	
 <h1>ANTLR Development Tools</h1>
 
-<img align=left src="images/icons/rocket.png">There are plug-ins for
-Intellij, NetBeans, Eclipse, Visual Studio Code, Visual Studio IDE, and jEdit.<br><br>
+<img align=left src="images/icons/rocket.png">There are plug-ins for Intellij, NetBeans, Eclipse, Visual Studio Code, Visual Studio IDE, and jEdit.<br><br>
 
 <h2>Intellij Plugin for ANTLR 4</h2>
 
@@ -212,6 +211,7 @@ Ken Domino created an
 <li>Intellisense command completion and tooltips.
 <li>Go to def/refs.
 <li>Go to C# visitor and listener methods, with generation if missing.
+<li>Reformat using Codebuff.
 <li>Support for integrated C# parser generation via Antlr Java tool, compile, and debug.
 <li>Templates for NET Code and Framework Antlr examples.
 </ul>


### PR DESCRIPTION
I just did a rewrite my extension for Antlr for Visual Studio 2019, because the other extensions that used to be available don't support VS2019. This one wraps the Antlr Java tool for full support of an edit-generate parser-compile-debug cycle in C#. I'd like to add it to the list of available developer tools for Antlr. --Ken Domino