### PR TITLE
Fix pragprog.com book links

### DIFF
--- a/index.html
+++ b/index.html
@@ -165,7 +165,7 @@ an ugly wart from my grammar. Hats off!
 ANTLR is an exceptionally powerful and flexible tool for parsing
 formal languages. At Twitter, we use it exclusively for query parsing
 in Twitter search. Our grammars are clean and concise, and the
-generated code is efficient and stable. The <a href="http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference">book</a> is our go-to
+generated code is efficient and stable. The <a href="http://pragprog.com/titles/tpantlr2/the-definitive-antlr-4-reference">book</a> is our go-to
 reference for ANTLR v4 -- engaging writing, clear descriptions and
 practical examples all in one place.
 <strong>Samuel Luckenbill, Senior Manager of Search Infrastructure, Twitter, inc.</strong>
@@ -193,9 +193,9 @@ day. Nice work!
 <div class="col3" id="resources">
 <h2>Resources</h2>	
 
-<a href="http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference"><img src="images/tpantlr2.jpg"
+<a href="http://pragprog.com/titles/tpantlr2/the-definitive-antlr-4-reference"><img src="images/tpantlr2.jpg"
 width=110></a>
-<a href="http://pragprog.com/book/tpdsl/language-implementation-patterns"><img src="images/tpdsl.jpg"
+<a href="http://pragprog.com/titles/tpdsl/language-implementation-patterns"><img src="images/tpdsl.jpg"
 width=110></a>
 
 <br><br><a href="https://github.com/antlr/antlr4/blob/master/doc/getting-started.md">Getting started with ANTLR v4</a>

--- a/scripts/bottomnav.js
+++ b/scripts/bottomnav.js
@@ -2,7 +2,7 @@ document.write("<ul>");
 document.write("<li><a href='/index.html'>Index</a></li>");
 document.write("<li><a href='/download.html'>Download</a></li>\n");
 document.write("<li><a href='/tools.html'>Dev Tools</a></li> \n");
-document.write("<li><a href='http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference'>Book</a></li> \n");
+document.write("<li><a href='http://pragprog.com/titles/tpantlr2/the-definitive-antlr-4-reference'>Book</a></li> \n");
 document.write("<li><a href='https://github.com/antlr/antlr4/blob/4.6/doc/index.md'>Doc</a></li>\n");
 document.write("<li><a href='/about.html'>About ANTLR</a></li>\n");
 document.write("<li><a href='/support.html'>Support</a></li>  \n");

--- a/scripts/leftnav.js
+++ b/scripts/leftnav.js
@@ -4,7 +4,7 @@ document.write("<li><a href='/download.html'>Download</a></li>");
 document.write("<li>Resources");
 document.write("<ul>");
 document.write("<li><a href='https://github.com/antlr/antlr4/blob/master/doc/getting-started.md'>Getting Started</a></li>");
-document.write("<li><a href='http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference'>ANTLR v4 Book</a></li>");
+document.write("<li><a href='http://pragprog.com/titles/tpantlr2/the-definitive-antlr-4-reference'>ANTLR v4 Book</a></li>");
 document.write("<li><a href='https://github.com/antlr/antlr4/blob/4.6/doc/index.md'>Documentation</a></li>");
 document.write("<li><a href='/api'>Runtime API</a></li>");
 document.write("<li><a href='http://pragprog.com/titles/tpantlr2/source_code'>Examples (from book)</a></li>");

--- a/scripts/topnav.js
+++ b/scripts/topnav.js
@@ -1,7 +1,7 @@
 document.write("<ul>");
 document.write("<li><a href='/download.html'>Download<span>v4.13.1</span></a></li>\n");
 document.write("<li><a href='/tools.html'>Dev Tools</a></li> \n");
-document.write("<li><a href='http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference'>Book</a></li> \n");
+document.write("<li><a href='http://pragprog.com/titles/tpantlr2/the-definitive-antlr-4-reference'>Book</a></li> \n");
 document.write("<li><a href='https://github.com/antlr/antlr4/blob/master/doc/index.md'>Doc</a></li>\n");
 document.write("<li><a href='/about.html'>About ANTLR</a></li>\n");
 document.write("<li><a href='/support.html'>Support</a></li>  \n");

--- a/testimonials.html
+++ b/testimonials.html
@@ -76,7 +76,7 @@ an ugly wart from my grammar. Hats off!</i><br>
 ANTLR is an exceptionally powerful and flexible tool for parsing
 formal languages. At Twitter, we use it exclusively for query parsing
 in Twitter search. Our grammars are clean and concise, and the
-generated code is efficient and stable. The <a href="http://pragprog.com/book/tpantlr2/the-definitive-antlr-4-reference">book</a> is our go-to
+generated code is efficient and stable. The <a href="http://pragprog.com/titles/tpantlr2/the-definitive-antlr-4-reference">book</a> is our go-to
 reference for ANTLR v4 -- engaging writing, clear descriptions and
 practical examples all in one place.</i><br>
 <strong>Samuel Luckenbill, Senior Manager of Search Infrastructure, Twitter, inc.</strong>


### PR DESCRIPTION
The /book/ URLs all lead to their search for "t" now.
This PR replaces the /book/ URLS with the (new?) /titles/ one.

fixes antlr/antlr4#4494